### PR TITLE
Catered for liveness and readiness probe when ingress supplied

### DIFF
--- a/deploy/helm/hello-kubernetes/templates/deployment.yaml
+++ b/deploy/helm/hello-kubernetes/templates/deployment.yaml
@@ -25,11 +25,19 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
+              {{- if and .Values.ingress.configured (not .Values.ingress.rewritePath) }}
+              path: "/{{ .Values.ingress.pathPrefix }}"
+              {{- else }}
               path: /
+              {{- end }}
               port: http
           readinessProbe:
             httpGet:
+              {{- if and .Values.ingress.configured (not .Values.ingress.rewritePath) }}
+              path: "/{{ .Values.ingress.pathPrefix }}"
+              {{- else }}
               path: /
+              {{- end }}
               port: http
           env:
           {{- if ne (.Values.deployment.container.port | int) (8080 | int) }}


### PR DESCRIPTION
Currently when deploying into a Kubernetes cluster with own ingress configured which uses specific path prefix which is not rewritten the liveness and readiness probes fail. This is because the deployment does not take into consideration the path prefix in the liveness and readiness url's even when it should. It is always your [deployment.yaml](https://github.com/paulbouwer/hello-kubernetes/blob/main/deploy/helm/hello-kubernetes/templates/deployment.yaml)

```yaml
      livenessProbe:
        httpGet:
          path: /
          port: http
      readinessProbe:
        httpGet:
          path: /
          port: http
```
This pull request updates this section to include the path when the ingress is configured (ingress.configured=true) and the path is not being rewritten in the ingress (ingress.rewritePath=false) as per my [deployment.yaml](https://github.com/khetho/hello-kubernetes/blob/main/deploy/helm/hello-kubernetes/templates/deployment.yaml)

```yaml
      livenessProbe:
        httpGet:
          {{- if and .Values.ingress.configured (not .Values.ingress.rewritePath) }}
          path: "/{{ .Values.ingress.pathPrefix }}"
          {{- else }}
          path: /
          {{- end }}
          port: http
      readinessProbe:
        httpGet:
          {{- if and .Values.ingress.configured (not .Values.ingress.rewritePath) }}
          path: "/{{ .Values.ingress.pathPrefix }}"
          {{- else }}
          path: /
          {{- end }}
          port: http
```
