### PR TITLE
Multi arch support

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -14,9 +14,12 @@ jobs:
 
     env:
       CONTAINER_REGISTRY: docker.io
-      CONTAINER_IMAGE: ${{ github.repository }}
 
     steps:
+      - name: Lowercase env
+        run: |
+          echo "CONTAINER_IMAGE=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:

--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       -
         name: Login to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -17,6 +17,11 @@ jobs:
       CONTAINER_IMAGE: paulbouwer/hello-kubernetes
 
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+          install: true
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       CONTAINER_REGISTRY: docker.io
-      CONTAINER_IMAGE: paulbouwer/hello-kubernetes
+      CONTAINER_IMAGE: ${{ github.repository }}
 
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -20,7 +20,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
           install: true
 
       - name: Checkout code
@@ -39,6 +38,7 @@ jobs:
       - name: Build image
         run: | 
           docker build --tag "$IMAGE:$IMAGE_VERSION" \
+            --platform linux/amd64,linux/arm64 \
             --build-arg IMAGE_VERSION="$IMAGE_VERSION" \
             --build-arg IMAGE_CREATE_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" \
             --build-arg IMAGE_SOURCE_REVISION="`git rev-parse HEAD`" \

--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -1,63 +1,77 @@
 name: "When a release tag is created, build and publish a new version of the container image"
 
 on:
-
-  create
-
+  create:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches:
+      - "main"
 jobs:
-
   build-and-push-container-image:
-
     runs-on: ubuntu-latest
-
-    if: startsWith(github.ref, 'refs/tags/v')
-
-    env:
-      CONTAINER_REGISTRY: docker.io
-
     steps:
-      - name: Lowercase env
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Initialize Environment
         run: |
-          echo "CONTAINER_IMAGE=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
-        
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          install: true
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Build image and version variables
-        run: |
-          echo "IMAGE=$CONTAINER_REGISTRY/$CONTAINER_IMAGE" >> $GITHUB_ENV
           echo "IMAGE_VERSION=$(cat src/app/package.json | jq -r .version)" >> $GITHUB_ENV
-          
-      - name: Build additional image tag variables
-        run: |
-          echo "IMAGE_MAJOR_VERSION=$(echo $IMAGE_VERSION | cut -d '.' -f1)" >> $GITHUB_ENV
-          echo "IMAGE_MINOR_VERSION=$(echo $IMAGE_VERSION | cut -d '.' -f2)" >> $GITHUB_ENV
-
-      - name: Build image
-        run: | 
-          docker build --tag "$IMAGE:$IMAGE_VERSION" \
-            --platform linux/amd64,linux/arm64 \
-            --build-arg IMAGE_VERSION="$IMAGE_VERSION" \
-            --build-arg IMAGE_CREATE_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" \
-            --build-arg IMAGE_SOURCE_REVISION="`git rev-parse HEAD`" \
-            --file src/app/Dockerfile src/app
-
-      - name: Create additional image tags
-        run: |
-          docker tag $IMAGE:$IMAGE_VERSION $IMAGE:$IMAGE_MAJOR_VERSION
-          docker tag $IMAGE:$IMAGE_VERSION $IMAGE:$IMAGE_MAJOR_VERSION.$IMAGE_MINOR_VERSION
-
-      - name: Log into registry
-        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-
-      - name: Push image and tags to registry
-        run: |
-          docker push $IMAGE:$IMAGE_VERSION
-          docker push $IMAGE:$IMAGE_MAJOR_VERSION
-          docker push $IMAGE:$IMAGE_MAJOR_VERSION.$IMAGE_MINOR_VERSION
-
+          echo "IMAGE_CREATE_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"          >> $GITHUB_ENV
+          echo "IMAGE_SOURCE_REVISION=$(git rev-parse HEAD)"                 >> $GITHUB_ENV
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: src/app
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            "IMAGE_VERSION=${{ env.IMAGE_VERSION }}"
+            "IMAGE_CREATE_DATE=${{ env.IMAGE_CREATE_DATE }}"
+            "IMAGE_SOURCE_REVISION=${{ env.IMAGE_SOURCE_REVISION }}"

--- a/src/app/Dockerfile
+++ b/src/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.13
+FROM node:19-alpine
 
 ARG IMAGE_CREATE_DATE
 ARG IMAGE_VERSION

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -28,4 +28,3 @@ The application relies on the following files for configuration and operational 
 | File | Required | Information | Description |
 | ---- | -------- | ----------- | ----------- |
 | package.json | Yes | `.version` | The release version is used when the CONTAINER_IMAGE env is not provided. |
-| info.json | Yes | `.containerImageArch` | The container image architecture is used for display. This file will be overwritten in future versions as part of the container image build process when multi-arch images are supported. |

--- a/src/app/info.json
+++ b/src/app/info.json
@@ -1,3 +1,0 @@
-{
-  "containerImageArch": "linux/amd64"
-}

--- a/src/app/server.js
+++ b/src/app/server.js
@@ -33,8 +33,8 @@ var podName = process.env.KUBERNETES_POD_NAME || os.hostname();
 var nodeName = process.env.KUBERNETES_NODE_NAME || '-';
 var nodeOS = os.type() + ' ' + os.release();
 var applicationVersion = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
-var containerImage = process.env.CONTAINER_IMAGE || 'paulbouwer/hello-kubernetes:' + applicationVersion
-var containerImageArch = JSON.parse(fs.readFileSync('info.json', 'utf8')).containerImageArch;
+var containerImage = process.env.CONTAINER_IMAGE || 'paulbouwer/hello-kubernetes:' + applicationVersion;
+var containerImageArch = os.platform() + '/' + os.arch();
 
 logger.debug();
 logger.debug('Configuration');


### PR DESCRIPTION
modified build and publish workflow:
- use native docker action to tag image
- use native docker action to login to multiple registries (GH, docker)
- use native docker action to build image with multi arch support (linux amd64 + linux arm64)

updated `server.js` to dynamically get arch