### PR TITLE
Switch CI publish target to GHCR under repo owner

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -1,8 +1,12 @@
-name: "When a release tag is created, build and publish a new version of the container image"
+name: "Build and publish container image"
 
 on:
-
-  create
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 jobs:
 
@@ -10,46 +14,57 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
 
     env:
-      CONTAINER_REGISTRY: docker.io
-      CONTAINER_IMAGE: paulbouwer/hello-kubernetes
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/hello-kubernetes
 
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Build image and version variables
+      - name: Resolve image version
+        id: version
+        shell: bash
         run: |
-          echo "IMAGE=$CONTAINER_REGISTRY/$CONTAINER_IMAGE" >> $GITHUB_ENV
-          echo "IMAGE_VERSION=$(cat src/app/package.json | jq -r .version)" >> $GITHUB_ENV
-          
-      - name: Build additional image tag variables
-        run: |
-          echo "IMAGE_MAJOR_VERSION=$(echo $IMAGE_VERSION | cut -d '.' -f1)" >> $GITHUB_ENV
-          echo "IMAGE_MINOR_VERSION=$(echo $IMAGE_VERSION | cut -d '.' -f2)" >> $GITHUB_ENV
+          PKG_VERSION=$(jq -r .version src/app/package.json)
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="${PKG_VERSION}-sha.${GITHUB_SHA::7}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          MAJOR="${VERSION%%.*}"
+          MINOR_RAW="${VERSION#*.}"
+          MINOR="${MINOR_RAW%%.*}"
+          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
+          echo "minor=${MAJOR}.${MINOR}" >> "$GITHUB_OUTPUT"
 
-      - name: Build image
-        run: | 
-          docker build --tag "$IMAGE:$IMAGE_VERSION" \
-            --build-arg IMAGE_VERSION="$IMAGE_VERSION" \
-            --build-arg IMAGE_CREATE_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" \
-            --build-arg IMAGE_SOURCE_REVISION="`git rev-parse HEAD`" \
-            --file src/app/Dockerfile src/app
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create additional image tags
-        run: |
-          docker tag $IMAGE:$IMAGE_VERSION $IMAGE:$IMAGE_MAJOR_VERSION
-          docker tag $IMAGE:$IMAGE_VERSION $IMAGE:$IMAGE_MAJOR_VERSION.$IMAGE_MINOR_VERSION
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log into registry
-        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-
-      - name: Push image and tags to registry
-        run: |
-          docker push $IMAGE:$IMAGE_VERSION
-          docker push $IMAGE:$IMAGE_MAJOR_VERSION
-          docker push $IMAGE:$IMAGE_MAJOR_VERSION.$IMAGE_MINOR_VERSION
-
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: src/app
+          file: src/app/Dockerfile
+          push: true
+          build-args: |
+            IMAGE_VERSION=${{ steps.version.outputs.version }}
+            IMAGE_CREATE_DATE=${{ github.event.repository.updated_at }}
+            IMAGE_SOURCE_REVISION=${{ github.sha }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.minor }}


### PR DESCRIPTION
## Summary
- Build on push to main and v* tag (plus workflow_dispatch for on-demand)
- Publish to ghcr.io/${owner}/hello-kubernetes so this fork can build without DockerHub secrets
- Uses the built-in GITHUB_TOKEN via docker/login-action@v3

## Test plan
- [ ] Merge; confirm the push-to-main run succeeds and publishes an image to `ghcr.io/egorpavlikhin/hello-kubernetes`
- [ ] Octopus feed at ghcr.io resolves the published tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)